### PR TITLE
Add env to create multiple mail accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Edit ```docker-compose.yml``` for set these environment variables:
 - MAILNAME: Mail domain (by default, `localdomain.test`)
 - MAIL_ADDRESS: Normal user mailbox email address (optional)
 - MAIL_PASS: Normal user mailbox password
+- MAIL_ACCOUNTS: A list of accounts to create `alice@domain.com,password bob@domain.com,password`
 
 ```
 docker-compose up

--- a/entrypoint
+++ b/entrypoint
@@ -117,6 +117,15 @@ if [ -n "$MAIL_ADDRESS" ]; then
     _add_line "$MAIL_ADDRESS" "/$MAIL_ADDRESS/ $MAIL_ADDRESS" /etc/postfix/virtual_regexp
 fi
 
+# Create user accounts
+if [ -n "$MAIL_ACCOUNTS" ]; then
+    for MAIL_ACCOUNT in ${MAIL_ACCOUNTS}; do
+        IFS=',' read account_login account_password <<< "${MAIL_ACCOUNT}"
+        _account_add "$account_login" "$account_password"
+        _add_line "$account_login" "/$account_login/ $account_login" /etc/postfix/virtual_regexp
+    done
+fi
+
 # Create debug account
 _account_add "$DEBUG_ADDRESS" "$DEBUG_PASS"
 


### PR DESCRIPTION
To test provisioning configuration it's nice to have more than one account.