### PR TITLE
Join lines for postconf -e

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -95,7 +95,7 @@ if [ -n "$HOSTNAME" ]; then
     /usr/sbin/postconf -e myhostname=$HOSTNAME
 fi
 
-routes=$(ip route | grep -v default | cut -d' ' -f1)
+routes=$(ip route | grep -v default | cut -d' ' -f1 | tr '\n' ' ')
 if [ -n "$routes" ]; then
     /usr/sbin/postconf -e mynetworks="127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128 $routes"
     /usr/sbin/postconf -e inet_interfaces=all


### PR DESCRIPTION
The command `postconf -e` fails if it receives multiple lines as input but `ip route` returns one line per route.

Note: This is only relevant when using `docker run --net=host`. 