### PR TITLE
Enable acls

### DIFF
--- a/dovecot/10-mail.conf
+++ b/dovecot/10-mail.conf
@@ -46,7 +46,7 @@ namespace inbox {
   # Hierarchy separator to use. You should use the same separator for all
   # namespaces or some clients get confused. '/' is usually a good one.
   # The default however depends on the underlying mail storage format.
-  #separator = 
+  separator = /
 
   # Prefix required to access this namespace. This needs to be different for
   # all namespaces. For example "Public/".
@@ -77,28 +77,29 @@ namespace inbox {
   #subscriptions = yes
 }
 
-# Example shared namespace configuration
-#namespace {
-  #type = shared
-  #separator = /
+# Enable shared mailboxes
+# https://doc.dovecot.org/configuration_manual/shared_mailboxes/shared_mailboxes/#mailbox-sharing-between-users
+namespace {
+  type = shared
+  separator = /
 
   # Mailboxes are visible under "shared/user@domain/"
   # %%n, %%d and %%u are expanded to the destination user.
-  #prefix = shared/%%u/
+  prefix = shared/%%u/
 
   # Mail location for other users' mailboxes. Note that %variables and ~/
   # expands to the logged in user's data. %%n, %%d, %%u and %%h expand to the
   # destination user's data.
-  #location = maildir:%%h/Maildir:INDEX=~/Maildir/shared/%%u
+  location = maildir:/var/mail/%%d/%%n:INDEXPVT=/var/mail/%d/%n/shared
 
   # Use the default namespace for saving subscriptions.
-  #subscriptions = no
+  subscriptions = no
 
   # List the shared/ namespace only if there are visible shared mailboxes.
-  #list = children
-#}
+  list = children
+}
 # Should shared INBOX be visible as "shared/user" or "shared/user/INBOX"?
-#mail_shared_explicit_inbox = no
+mail_shared_explicit_inbox = yes
 
 # System user and group used to access mails. If you use multiple, userdb
 # can override these by returning uid or gid fields. You can use either numbers

--- a/dovecot/10-master.conf
+++ b/dovecot/10-master.conf
@@ -128,6 +128,28 @@ service dict {
   }
 }
 
+# Enable the IMAP ACL commands
+# https://doc.dovecot.org/configuration_manual/acl/
+mail_plugins = $mail_plugins acl
+
 protocol imap {
   mail_max_userip_connections = 30
+
+  # Enable the IMAP ACL commands
+  mail_plugins = $mail_plugins imap_acl
+
+  plugin {
+    acl = vfile
+
+    # If enabled, don't try to find dovecot-acl files from mailbox directories.
+    # This reduces unnecessary disk I/O when only global ACLs are used.
+    # (v2.2.31+)
+    #acl_globals_only = yes
+
+    # Namespace prefix to ignore. Use counter to ignore multiple, e.g. acl_ignore_namespace2
+    #acl_ignore_namespace =
+
+    # Dict for mapping which users have shared mailboxes to each other.
+    acl_shared_dict = file:/var/mail/shared-mailboxes.db
+  }
 }


### PR DESCRIPTION
This breaks all existing containers due to changing the separator from `.` to `/`. This is strictly necessary to make ACLs work (because email addresses contain dots).