### PR TITLE
feat(deps): Bump ubuntu base image from 16.04 to 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 LABEL org.opencontainers.image.source=https://github.com/ChristophWurst/docker-imap-devel
 


### PR DESCRIPTION
Built the image locally. Works.

cc @systemkeeper 