### PR TITLE
fix: relax open file ulimits for rsyslogd

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,3 +14,7 @@ services:
     - MAILNAME=domain.tld
     - MAIL_ADDRESS=user@domain.tld
     - MAIL_PASS=mypassword
+    ulimits:
+      nofile:
+        soft: 1024
+        hard: 524288


### PR DESCRIPTION
The rsyslogd service inside the container fails on systems running (docker/containerd) on systemd.

Ref https://github.com/rsyslog/rsyslog/issues/5158#issuecomment-1724558068 (have a look at the summary at the bottom of the comment for a TL;DR)

A fix has been upstreamed but is only available in bleeding edge Ubuntu and I won't bother updating the Dockerfile. Instead, here is a workaround to make the outdated version of rsyslogd work on systems running systemd.

## How to reproduce?

1. Run `docker compose up`
2. Wait some time for the services to start up.
3. Observe the log.

## Before

```
docker-imap-devel-imap-1  |  * Starting enhanced syslogd rsyslogd
docker-imap-devel-imap-1  | rsyslog startup failure, child did not respond within startup timeout (60 seconds)
docker-imap-devel-imap-1  |    ...done.
```

## After

```
docker-imap-devel-imap-1  |  * Starting enhanced syslogd rsyslogd
docker-imap-devel-imap-1  | rsyslogd: imklog: cannot open kernel log (/proc/kmsg): Operation not permitted.
docker-imap-devel-imap-1  | rsyslogd: activation of module imklog failed [v8.2001.0 try https://www.rsyslog.com/e/2145 ]
docker-imap-devel-imap-1  |    ...done.
```