### PR TITLE
Also build image for linux/arm64

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -47,4 +47,5 @@ jobs:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+          platforms: 'linux/amd64,linux/arm64'
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
On ARM-based macos the image for amd64 doesn't start but logs some strange error. A native image works well.